### PR TITLE
engine events should register after engine ready and before scene load

### DIFF
--- a/panel/scene-view/scene-view.js
+++ b/panel/scene-view/scene-view.js
@@ -218,6 +218,8 @@ Editor.registerElement({
 
         var self = this;
         cc.engine.init(initOptions, function () {
+            self.fire('engine-ready');
+
             Editor.initScene(function (err) {
                 if (err) {
                     self.fire('scene-view-init-error', err);

--- a/panel/scene.js
+++ b/panel/scene.js
@@ -35,6 +35,8 @@
             'drop-area-leave': '_onDropAreaLeave',
             'drop-area-accept': '_onDropAreaAccept',
 
+            'engine-ready': '_onEngineReady',
+
             'scene-view-ready': '_onSceneViewReady',
             'scene-view-init-error': '_onSceneViewInitError',
 
@@ -380,15 +382,17 @@
             }
         },
 
+        _onEngineReady: function () {
+            // register engine events, after engine ready and before scene load
+            const EngineEvents = Editor.require('packages://scene/panel/scene-view/engine-events');
+            EngineEvents.register(this.$.sceneView);
+        },
+
         // view events
         _onSceneViewReady: function () {
             this._viewReady = true;
             this.$.loader.hidden = true;
             this.undo.clear();
-
-            // register engine events
-            const EngineEvents = Editor.require('packages://scene/panel/scene-view/engine-events');
-            EngineEvents.register(this.$.sceneView);
 
             Editor.sendToAll('scene:ready');
 


### PR DESCRIPTION
engine events 还会注册 node-attach-to-scene 消息
所以需要在 engine ready 后， scene load 之前 初始化

update fireball-x/fireball#796
@jwu 